### PR TITLE
Publish release v2.128.111

### DIFF
--- a/blockchain/beacon/prysm_client.go
+++ b/blockchain/beacon/prysm_client.go
@@ -30,6 +30,7 @@ type PrysmClient struct {
 	endpoint    types.NodeEndpoint
 	beaconBlock bool
 	log         *log.Entry
+	latestSlot  prysmTypes.Slot
 }
 
 // NewPrysmClient creates new Prysm gRPC client
@@ -109,6 +110,12 @@ func (c *PrysmClient) run() {
 					c.log.Errorf("block slot=%d is too old to process", blk.Block().Slot())
 					continue
 				}
+
+				// only process new blocks
+				if c.latestSlot >= blk.Block().Slot() {
+					continue
+				}
+				c.latestSlot = blk.Block().Slot()
 
 				wrappedBlock := NewWrappedReadOnlySignedBeaconBlock(blk)
 				blockHash, err := wrappedBlock.HashTreeRoot()

--- a/bxmessage/mev_bundle.go
+++ b/bxmessage/mev_bundle.go
@@ -99,8 +99,8 @@ func NewMEVBundle(
 
 // String returns a string representation of the MEVBundle
 func (m MEVBundle) String() string {
-	return fmt.Sprintf("mev bundle(sender account ID: %s, hash: %s, blockNumber: %s, builders: %v, txs: %d, sent from cloud api: %v, tier: %v, allowMixedBundles: %v, UUID: %s)",
-		m.OriginalSenderAccountID, m.BundleHash, m.BlockNumber, m.MEVBuilders, len(m.Transactions), m.SentFromCloudAPI, m.OriginalSenderAccountTier, m.AvoidMixedBundles, m.UUID)
+	return fmt.Sprintf("mev bundle(sender account ID: %s, hash: %s, blockNumber: %s, builders: %v, txs: %d, sent from cloud api: %v, tier: %v, allowMixedBundles: %v, UUID: %s, EnforcePayout %v, BundlePrice %v, MinTimestamp %v , MaxTimestamp %v, RevertingHashes %v)",
+		m.OriginalSenderAccountID, m.BundleHash, m.BlockNumber, m.MEVBuilders, len(m.Transactions), m.SentFromCloudAPI, m.OriginalSenderAccountTier, m.AvoidMixedBundles, m.UUID, m.EnforcePayout, m.BundlePrice, m.MinTimestamp, m.MaxTimestamp, len(m.RevertingHashes))
 }
 
 // SetHash sets the hash based on the fields in BundleSubmission

--- a/connections/blockchain.go
+++ b/connections/blockchain.go
@@ -24,10 +24,18 @@ var blockchainTLSPlaceholder = TLS{}
 func NewBlockchainConn(ipEndpoint types.NodeEndpoint) Blockchain {
 	connType := utils.Blockchain.String()
 
+	var remoteAddr string
+	if ipEndpoint.DNS != "" {
+		remoteAddr = fmt.Sprintf("%v:%v", ipEndpoint.DNS, ipEndpoint.Port)
+	} else {
+		remoteAddr = fmt.Sprintf("%v:%v", ipEndpoint.IP, ipEndpoint.Port)
+	}
+
 	return Blockchain{
 		endpoint: ipEndpoint,
 		log: log.WithFields(log.Fields{
-			"connType": connType,
+			"connType":   connType,
+			"remoteAddr": remoteAddr,
 		}),
 	}
 }

--- a/nodes/gateway.go
+++ b/nodes/gateway.go
@@ -1332,9 +1332,12 @@ func (g *gateway) handleBeaconMessageFromBlockchain(beaconMessage *bxmessage.Bea
 			return err
 		}
 
-		err = g.blobsManager.AddBlobSidecar(blobSidecar)
-		if err != nil {
-			g.log.Errorf("failed to add blob sidecar: %v", err)
+		if g.blobsManager != nil {
+			err = g.blobsManager.AddBlobSidecar(blobSidecar)
+
+			if err != nil {
+				g.log.Errorf("failed to add blob sidecar: %v", err)
+			}
 		}
 	default:
 		g.log.Errorf("unknown beacon message type %v", beaconMessage.Type())

--- a/test/bxmock/eth_tx.go
+++ b/test/bxmock/eth_tx.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/holiman/uint256"
 )
 
@@ -117,6 +118,11 @@ func newEthBlobTx(nonce uint64, privateKey *ecdsa.PrivateKey, chainID *uint256.I
 		Data:       []byte{},
 		BlobFeeCap: uint256.NewInt(100),
 		BlobHashes: []common.Hash{},
+		Sidecar: &ethtypes.BlobTxSidecar{
+			Blobs:       []kzg4844.Blob{},
+			Commitments: []kzg4844.Commitment{},
+			Proofs:      []kzg4844.Proof{},
+		},
 		AccessList: nil,
 		V:          nil,
 		R:          nil,

--- a/types/eth_transaction.go
+++ b/types/eth_transaction.go
@@ -308,6 +308,25 @@ func (et *EthTransaction) EffectiveGasTipCap() *big.Int {
 	return et.tx.GasPrice()
 }
 
+// EffectiveBlobGasFeeCap returns a common "gas fee per blob gas" that can be used for all types of transactions
+func (et *EthTransaction) EffectiveBlobGasFeeCap() *big.Int {
+	if et.Type() == ethtypes.BlobTxType {
+		return et.tx.BlobGasFeeCap()
+	}
+
+	return big.NewInt(0)
+}
+
+// EffectiveBlobGasFeeCapIntCmp make a compare for "blob gas fee cap" that can be used for all types of transactions
+func (et *EthTransaction) EffectiveBlobGasFeeCapIntCmp(other *big.Int) int {
+	if et.Type() == ethtypes.BlobTxType {
+		return et.tx.BlobGasFeeCap().Cmp(other)
+	}
+
+	// Legacy and dynamic fee transactions have no blob gas fee cap
+	return 1
+}
+
 // ChainID returns the chain ID of the transaction
 func (et *EthTransaction) ChainID() *big.Int {
 	return et.tx.ChainId()


### PR DESCRIPTION
# Release notes
- Old blocks check added, prevent unsynced peers to spam gateway with old blocks.
- MevBundle `frontrunning` field has been removed, `AvoidMixedBundles` field has been added.
- `--mev-max-profit-builder` startup argument removed.
- Allow Gateway to use DNS in `multiaddr`.
- Added support of `BlobGasFeeCap` checks for Blob transactions in `TxStore`.
- Added a context to the SDN related errors.
- Allow Gateway to accept incoming Beacon P2P connections
- `--beacon-port` argument added. Default 0 (disabled). If set, Gateway will accept incoming beacon P2P connections on a given port.
- `--beacon-trusted-peers-file` argument added. Default value `""`. If set, Gateway will only accept incoming beacon P2P connections which PeerIds are mentioned in the file.
- Added processing of Beacon API ping messages.
- Prevent processing multiple times the same block from Prysm gRPC.
- Websocket connection status fixed. Case when established connection was marked as `not_connected`.
- txReceipts feed: added blobs related fields.